### PR TITLE
Lock to web3.js 1.x for compatibility

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -1066,7 +1066,7 @@ Throw this command into your terminal to install all the `wallet-adapter` stuff
 we need:
 
 ```shell
-yarn add react @solana/web3.js \
+yarn add react @solana/web3.js@1 \
   @solana/wallet-adapter-base @solana/wallet-adapter-react \
   @solana/wallet-adapter-react-ui @solana/wallet-adapter-wallets
 ```


### PR DESCRIPTION
Read why, here: https://github.com/solana-labs/solana-web3.js/issues/3498